### PR TITLE
Support direct opening of .zip, .wastickers and .stickify files

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,6 +7,15 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 formatter:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -35,16 +35,6 @@ linter:
   # producing the lint.
   rules:
     avoid_print: false  # Uncomment to disable the `avoid_print` rule
-analyzer:
-  exclude:
-    - build/**
-    - android/**
-    - ios/**
-    - web/**
-    - windows/**
-    - macos/**
-    - linux/**
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,6 +20,45 @@
                 android:name="io.flutter.embedding.android.NormalTheme"
                 android:resource="@style/NormalTheme"
             />
+
+            <!-- Matches by MIME type (how most file managers send files) -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="file" />
+                <data android:scheme="content" />
+                <data android:mimeType="application/zip" />
+                <data android:mimeType="application/x-zip" />
+                <data android:mimeType="application/x-zip-compressed" />
+                <data android:mimeType="application/octet-stream" />
+            </intent-filter>
+
+            <!-- Matches content:// URIs when an app shares with wildcard MIME (*/*) and file extension -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" />
+                <data android:host="*" />
+                <data android:mimeType="*/*" />
+                <data android:pathPattern=".*\\.wastickers" />
+                <data android:pathPattern=".*\\.stickify" />
+                <data android:pathPattern=".*\\.zip" />
+            </intent-filter>
+
+            <!-- Matches file:// URIs (legacy / direct file paths) -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="file" />
+                <data android:pathPattern=".*\\.wastickers" />
+                <data android:pathPattern=".*\\.stickify" />
+                <data android:pathPattern=".*\\.zip" />
+            </intent-filter>
+
+
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/android/app/src/main/kotlin/de/loicezt/stickers/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/loicezt/stickers/MainActivity.kt
@@ -1,5 +1,8 @@
 package de.loicezt.stickers
 
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
 import android.os.Build
 import androidx.annotation.NonNull
 import androidx.annotation.RequiresApi
@@ -28,6 +31,43 @@ class MainActivity : FlutterActivity() {
     private val scope = CoroutineScope(
         Dispatchers.Main + SupervisorJob()
     )
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        handleViewIntent(intent)
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        handleViewIntent(intent)
+        setIntent(intent)
+        super.onNewIntent(intent)
+    }
+
+    private fun handleViewIntent(intent: Intent?) {
+        if (intent == null || intent.action != Intent.ACTION_VIEW) return
+
+        val uris = ArrayList<Uri>()
+        intent.data?.let { uris.add(it) }
+        intent.clipData?.let { clipData ->
+            for (i in 0 until clipData.itemCount) {
+                val itemUri = clipData.getItemAt(i).uri
+                if (itemUri != null && !uris.contains(itemUri)) {
+                    uris.add(itemUri)
+                }
+            }
+        }
+
+        if (uris.isEmpty()) return
+
+        if (uris.size == 1) {
+            intent.action = Intent.ACTION_SEND
+            intent.putExtra(Intent.EXTRA_STREAM, uris[0])
+        } else {
+            intent.action = Intent.ACTION_SEND_MULTIPLE
+            intent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, uris)
+        }
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)

--- a/build_all.cmd
+++ b/build_all.cmd
@@ -3,6 +3,7 @@ REM builds and renames all apks and the appbudle
 
 echo Cleaning...
 call flutter clean
+call flutter pub get
 
 echo Building split per abi...
 call flutter build apk --split-per-abi

--- a/build_all.sh
+++ b/build_all.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+# Builds and renames all APKs and the App Bundle on Linux
+
+echo "Cleaning..."
+flutter clean
+flutter pub get
+
+echo "Building split per ABI..."
+flutter build apk --split-per-abi
+
+echo "Building combined APK..."
+flutter build apk
+
+echo "Building App Bundle..."
+flutter build appbundle
+
+echo "Renaming files..."
+SHA=$(git rev-parse --short=7 HEAD)
+
+mv build/app/outputs/flutter-apk/app-arm64-v8a-release.apk "build/app/outputs/flutter-apk/stickers-${SHA}-arm64-v8a.apk"
+mv build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk "build/app/outputs/flutter-apk/stickers-${SHA}-armeabi-v7a.apk"
+mv build/app/outputs/flutter-apk/app-x86_64-release.apk "build/app/outputs/flutter-apk/stickers-${SHA}-x86_64.apk"
+mv build/app/outputs/flutter-apk/app-release.apk "build/app/outputs/flutter-apk/stickers-${SHA}.apk"
+
+echo "Done!"

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -182,24 +182,36 @@ class StickersAppState extends State<StickersApp> {
   }
 
   Future<void> _processMedia(SharedMedia media) async {
-    if (media.attachments!.first!.path.toLowerCase().endsWith(".stickify") ||
-        media.attachments!.first!.path.toLowerCase().endsWith(".zip") ||
-        media.attachments!.first!.path.toLowerCase().endsWith(".wastickers")) {
-      try {
-        await importPack(File(media.attachments!.first!.path));
-        if (context.mounted) setState(() {});
-      } on Exception catch (_) {
-        if (mounted) {
-          showDialog(
-              context: navigatorKey.currentState!.context,
-              builder: (context) => ErrorDialog(
-                    message: AppLocalizations.of(context)!.checkIfFileValid,
-                    title: AppLocalizations.of(context)!.importError,
-                  ));
+    if (media.attachments == null || media.attachments!.isEmpty) return;
+
+    final packAttachments = media.attachments!.where((a) {
+      if (a == null) return false;
+      final p = a.path.toLowerCase();
+      return p.endsWith(".stickify") || p.endsWith(".zip") || p.endsWith(".wastickers");
+    }).toList();
+
+    if (packAttachments.isNotEmpty) {
+      for (final attachment in packAttachments) {
+        try {
+          await importPack(File(attachment!.path));
+          if (mounted) setState(() {});
+          homeState?.update();
+        } on Exception catch (e, st) {
+          debugPrint(e.toString());
+          debugPrintStack(stackTrace: st);
+          if (mounted) {
+            showDialog(
+                context: navigatorKey.currentState!.context,
+                builder: (context) => ErrorDialog(
+                      message: AppLocalizations.of(context)!.checkIfFileValid,
+                      title: AppLocalizations.of(context)!.importError,
+                    ));
+          }
         }
       }
       return;
     }
+
     if (media.attachments!.first!.type != SharedAttachmentType.image) {
       if (mounted) {
         showDialog(


### PR DESCRIPTION
- Added support for opening sticker pack files (`.zip`, `.wastickers` and `.stickify`) directly when users click on them from file managers, chat apps, or browsers in addition to the existing "share with" flow.
- updated some build configuration versions and made things a bit more robust (no breaking changes)
- added a linux build script same as the widows one, also added `call flutter pub get` to the windows one