### PR TITLE
Fixed tedious multi-sticker import

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1,4 +1,13 @@
 {
+  "reviewStickers": "Sticker prüfen",
+  "noStickersSelected": "Keine Bilder ausgewählt",
+  "cropSelectedSticker": "{name} zuschneiden",
+  "removeSelectedSticker": "{name} entfernen",
+  "resetCrop": "Zuschnitt zurücksetzen",
+  "saveCrop": "Zuschnitt speichern",
+  "saveAllStickers": "Alle speichern ({count})",
+  "savingStickers": "Vorbereitung: {current} von {total}",
+  "batchImportErrors": "Es wurde nichts gespeichert. Schneide die markierten Bilder zu oder entferne sie und versuche es erneut.",
     "@@locale": "de",
     "@@author": "lolocomotive",
     "appTitle": "Stickers",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,4 +1,44 @@
 {
+  "reviewStickers": "Review stickers",
+  "noStickersSelected": "No images selected",
+  "cropSelectedSticker": "Crop {name}",
+  "removeSelectedSticker": "Remove {name}",
+  "resetCrop": "Reset crop",
+  "saveCrop": "Save crop",
+  "saveAllStickers": "Save all ({count})",
+  "savingStickers": "Preparing {current} of {total}",
+  "batchImportErrors": "Nothing was saved. Crop or remove the marked images, then try again.",
+  "@saveAllStickers": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@savingStickers": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "@cropSelectedSticker": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "@removeSelectedSticker": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "@@locale": "en",
   "@@author": "lolocomotive",
   "appTitle": "Sticker maker",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1,4 +1,13 @@
 {
+  "reviewStickers": "Vérifier les stickers",
+  "noStickersSelected": "Aucune image sélectionnée",
+  "cropSelectedSticker": "Recadrer {name}",
+  "removeSelectedSticker": "Retirer {name}",
+  "resetCrop": "Réinitialiser le recadrage",
+  "saveCrop": "Enregistrer le recadrage",
+  "saveAllStickers": "Tout enregistrer ({count})",
+  "savingStickers": "Préparation de {current} sur {total}",
+  "batchImportErrors": "Rien n’a été enregistré. Recadrez ou retirez les images signalées, puis réessayez.",
   "@@locale": "fr",
   "@@author": "lolocomotive",
   "appTitle": "Stickers",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1,4 +1,13 @@
 {
+  "reviewStickers": "Просмотр стикеров",
+  "noStickersSelected": "Изображения не выбраны",
+  "cropSelectedSticker": "Обрезать {name}",
+  "removeSelectedSticker": "Удалить {name}",
+  "resetCrop": "Сбросить обрезку",
+  "saveCrop": "Сохранить обрезку",
+  "saveAllStickers": "Сохранить всё ({count})",
+  "savingStickers": "Подготовка: {current} из {total}",
+  "batchImportErrors": "Ничего не сохранено. Обрежьте или удалите отмеченные изображения и повторите попытку.",
   "@@locale": "ru",
   "@@author": "lolocomotive",
   "appTitle": "Стикеры",

--- a/lib/src/data/batch_import.dart
+++ b/lib/src/data/batch_import.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:stickers/src/data/load_store.dart';
+import 'package:stickers/src/data/sticker.dart';
+import 'package:stickers/src/data/sticker_pack.dart';
+import 'package:stickers/src/globals.dart';
+
+/// Converts the whole image to a sticker without trimming its content.
+Future<Uint8List> prepareUncroppedSticker(String path, StickerPack pack) async {
+  final bytes = await File(path).readAsBytes();
+  final codec = await instantiateImageCodec(bytes);
+  try {
+    final frame = await codec.getNextFrame();
+    try {
+      return await cropSticker(
+        Rect.fromLTWH(0, 0, frame.image.width.toDouble(), frame.image.height.toDouble()),
+        bytes,
+        pack,
+        0,
+        0,
+      );
+    } finally {
+      frame.image.dispose();
+    }
+  } finally {
+    codec.dispose();
+  }
+}
+
+/// Writes the entire batch before publishing it to the pack. A failure rolls
+/// back the new entries and files, so retrying never duplicates earlier items.
+Future<void> saveStickerBatch(StickerPack pack, List<Uint8List> images) async {
+  if (images.isEmpty) return;
+  if (pack.animated || pack.stickers.length + images.length > 30) {
+    throw StateError('The selected images do not fit in this static sticker pack.');
+  }
+  final directory = Directory('$packsDir/${pack.id}');
+  await directory.create(recursive: true);
+  final batchDirectory = await directory.createTemp('batch_');
+  final added = <Sticker>[];
+  final previousVersion = pack.imageDataVersion;
+  try {
+    for (var i = 0; i < images.length; i++) {
+      final file = File('${batchDirectory.path}/$i.webp');
+      await file.writeAsBytes(images[i], flush: true);
+      added.add(Sticker(file.path, ['❤'], null));
+    }
+    // Recheck after asynchronous file writes in case the pack changed.
+    if (pack.stickers.length + added.length > 30) {
+      throw StateError('The sticker pack is full.');
+    }
+    pack.stickers.addAll(added);
+    pack.imageDataVersion = (int.parse(previousVersion) + 1).toString();
+    final manifest = File('$packsDir/packs.json');
+    final temporaryManifest = File('${batchDirectory.path}/packs.json');
+    await temporaryManifest.writeAsString(jsonEncode(packs.map((p) => p.toJson()).toList()), flush: true);
+    await temporaryManifest.rename(manifest.path);
+  } catch (_) {
+    pack.stickers.removeWhere(added.contains);
+    pack.imageDataVersion = previousVersion;
+    await batchDirectory.delete(recursive: true);
+    rethrow;
+  }
+}

--- a/lib/src/pages/crop_page.dart
+++ b/lib/src/pages/crop_page.dart
@@ -9,18 +9,21 @@ import 'package:stickers/generated/intl/app_localizations.dart';
 import 'package:stickers/src/checker_painter.dart';
 import 'package:stickers/src/data/load_store.dart';
 import 'package:stickers/src/data/sticker_pack.dart';
+import 'package:stickers/src/dialogs/error_dialog.dart';
 import 'package:stickers/src/pages/default_page.dart';
 
 class CropPage extends StatefulWidget {
   final StickerPack pack;
   final int index;
   final String imagePath;
+  final bool returnCrop;
   final GlobalKey<ExtendedImageEditorState> editorKey = GlobalKey<ExtendedImageEditorState>();
 
   CropPage({
     required this.pack,
     required this.index,
     required this.imagePath,
+    this.returnCrop = false,
     super.key,
   });
 
@@ -35,6 +38,7 @@ class _CropPageState extends State<CropPage> with TickerProviderStateMixin {
   final ImageEditorController _editorController = ImageEditorController();
 
   bool _previousPtrVal = false;
+  bool _saving = false;
 
   @override
   void initState() {
@@ -254,8 +258,12 @@ class _CropPageState extends State<CropPage> with TickerProviderStateMixin {
                     Padding(
                       padding: const EdgeInsets.fromLTRB(16, 4, 16, 16),
                       child: FilledButton(
-                        onPressed: _onDone,
-                        child: Text(AppLocalizations.of(context)!.done),
+                        onPressed: _saving ? null : _onDone,
+                        child: Text(
+                          widget.returnCrop
+                              ? AppLocalizations.of(context)!.saveCrop
+                              : AppLocalizations.of(context)!.done,
+                        ),
                       ),
                     ),
                   ],
@@ -268,8 +276,11 @@ class _CropPageState extends State<CropPage> with TickerProviderStateMixin {
     );
   }
 
-  void _onDone() async {
+  Future<void> _onDone() async {
+    if (_saving) return;
+    if (widget.editorKey.currentState == null) return;
     final state = widget.editorKey.currentState!;
+    if (state.getCropRect() == null) return;
     if (state.getCropRect()!.height < .5 || state.getCropRect()!.width < .5) {
       showDialog(
         context: context,
@@ -284,24 +295,37 @@ class _CropPageState extends State<CropPage> with TickerProviderStateMixin {
       );
       return;
     }
-    final cropped = await cropSticker(
-      state.getCropRect()!,
-      state.rawImageData,
-      widget.pack,
-      widget.index,
-      _editorController.rotateDegrees,
-      _stretch,
-    );
-    final output = await saveTemp(cropped);
-    if (!mounted) return;
-    Navigator.of(context).pushNamed(
-      "/edit",
-      arguments: EditArguments(
-        pack: widget.pack,
-        index: widget.index,
-        mediaPath: output.path,
-      ),
-    );
+    setState(() => _saving = true);
+    try {
+      final cropped = await cropSticker(
+        state.getCropRect()!,
+        state.rawImageData,
+        widget.pack,
+        widget.index,
+        _editorController.rotateDegrees,
+        _stretch,
+      );
+      if (!mounted) return;
+      if (widget.returnCrop) {
+        Navigator.of(context).pop(cropped);
+        return;
+      }
+      final output = await saveTemp(cropped);
+      if (!mounted) return;
+      Navigator.of(context).pushNamed(
+        "/edit",
+        arguments: EditArguments(pack: widget.pack, index: widget.index, mediaPath: output.path),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      await showDialog<void>(
+        context: context,
+        builder: (_) =>
+            ErrorDialog(title: AppLocalizations.of(context)!.couldntExportSticker, message: error.toString()),
+      );
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
   }
 }
 

--- a/lib/src/pages/multi_crop_page.dart
+++ b/lib/src/pages/multi_crop_page.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -154,13 +155,23 @@ class _MultiCropPageState extends State<MultiCropPage> {
                                             button: true,
                                             child: Padding(
                                               padding: const EdgeInsets.all(8),
-                                              child: selection.crop == null
-                                                  ? Image.file(
-                                                      File(selection.path),
-                                                      fit: BoxFit.contain,
-                                                      errorBuilder: (_, error, stack) => const Icon(Icons.broken_image),
-                                                    )
-                                                  : Image.memory(selection.crop!, fit: BoxFit.contain),
+                                              child: LayoutBuilder(
+                                                builder: (context, constraints) {
+                                                  final pixelRatio = MediaQuery.devicePixelRatioOf(context);
+                                                  return Image(
+                                                    image: ResizeImage(
+                                                      selection.crop == null
+                                                          ? FileImage(File(selection.path))
+                                                          : MemoryImage(selection.crop!),
+                                                      width: math.max(1, (constraints.maxWidth * pixelRatio).ceil()),
+                                                      height: math.max(1, (constraints.maxHeight * pixelRatio).ceil()),
+                                                      policy: ResizeImagePolicy.fit,
+                                                    ),
+                                                    fit: BoxFit.contain,
+                                                    errorBuilder: (_, error, stack) => const Icon(Icons.broken_image),
+                                                  );
+                                                },
+                                              ),
                                             ),
                                           ),
                                         ),

--- a/lib/src/pages/multi_crop_page.dart
+++ b/lib/src/pages/multi_crop_page.dart
@@ -1,0 +1,241 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:stickers/generated/intl/app_localizations.dart';
+import 'package:stickers/src/checker_painter.dart';
+import 'package:stickers/src/data/batch_import.dart';
+import 'package:stickers/src/data/sticker_pack.dart';
+import 'package:stickers/src/dialogs/error_dialog.dart';
+import 'package:stickers/src/pages/crop_page.dart';
+import 'package:stickers/src/pages/default_page.dart';
+import 'package:stickers/src/util.dart';
+
+class _Selection {
+  _Selection(this.path);
+
+  final String path;
+  Uint8List? crop;
+  String? error;
+
+  String get name => File(path).uri.pathSegments.last;
+}
+
+class MultiCropPage extends StatefulWidget {
+  const MultiCropPage({super.key, required this.pack, required this.paths, this.selectionWasLimited = false});
+
+  final StickerPack pack;
+  final List<String> paths;
+  final bool selectionWasLimited;
+
+  @override
+  State<MultiCropPage> createState() => _MultiCropPageState();
+}
+
+class _MultiCropPageState extends State<MultiCropPage> {
+  late final List<_Selection> _selections = widget.paths.map(_Selection.new).toList();
+  bool _saving = false;
+  bool _openingCrop = false;
+  int _prepared = 0;
+
+  Future<void> _crop(_Selection selection) async {
+    if (_saving || _openingCrop) return;
+    setState(() => _openingCrop = true);
+    try {
+      final result = await Navigator.of(context).push<Uint8List>(
+        MaterialPageRoute(
+          builder: (_) => CropPage(
+            pack: widget.pack,
+            index: 0,
+            imagePath: selection.path,
+            returnCrop: true,
+          ),
+        ),
+      );
+      if (!mounted || result == null) return;
+      setState(() {
+        selection.crop = result;
+        selection.error = null;
+      });
+    } finally {
+      if (mounted) setState(() => _openingCrop = false);
+    }
+  }
+
+  Future<void> _saveAll() async {
+    if (_saving || _openingCrop || _selections.isEmpty) return;
+    setState(() {
+      _saving = true;
+      _prepared = 0;
+    });
+    try {
+      final prepared = <Uint8List>[];
+      var failed = false;
+      for (final selection in _selections) {
+        try {
+          prepared.add(selection.crop ?? await prepareUncroppedSticker(selection.path, widget.pack));
+          selection.error = null;
+        } catch (error) {
+          selection.error = error.toString();
+          failed = true;
+        }
+        if (!mounted) return;
+        setState(() => _prepared++);
+      }
+      if (failed) return;
+      await saveStickerBatch(widget.pack, prepared);
+      if (!mounted) return;
+      // Re-enable popping before leaving the saving screen.
+      setState(() => _saving = false);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) Navigator.of(context).pop();
+      });
+    } catch (error) {
+      if (!mounted) return;
+      await showDialog<void>(
+        context: context,
+        builder: (_) => ErrorDialog(
+          title: AppLocalizations.of(context)!.couldntExportSticker,
+          message: error.toString(),
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final busy = _saving || _openingCrop;
+    final hasErrors = _selections.any((selection) => selection.error != null);
+    return PopScope(
+      canPop: !_saving,
+      child: DefaultActivity(
+        appBar: AppBar(title: Text(l10n.reviewStickers)),
+        child: SafeArea(
+          child: Column(
+            children: [
+              if (widget.selectionWasLimited)
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Text(l10n.youCanTHaveMoreThan30Stickers),
+                ),
+              Expanded(
+                child: _selections.isEmpty
+                    ? Center(child: Text(l10n.noStickersSelected))
+                    : GridView.builder(
+                        padding: const EdgeInsets.all(8),
+                        itemCount: _selections.length,
+                        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                          crossAxisCount: colCount(MediaQuery.sizeOf(context).width),
+                          crossAxisSpacing: 8,
+                          mainAxisSpacing: 8,
+                          childAspectRatio: .8,
+                        ),
+                        itemBuilder: (context, index) {
+                          final selection = _selections[index];
+                          return Column(
+                            key: ObjectKey(selection),
+                            children: [
+                              Expanded(
+                                child: ClipRRect(
+                                  borderRadius: BorderRadius.circular(24),
+                                  child: Material(
+                                    color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                                    child: Stack(
+                                      fit: StackFit.expand,
+                                      children: [
+                                        CustomPaint(painter: CheckerPainter(context)),
+                                        InkWell(
+                                          onTap: busy ? null : () => _crop(selection),
+                                          child: Semantics(
+                                            label: l10n.cropSelectedSticker(selection.name),
+                                            button: true,
+                                            child: Padding(
+                                              padding: const EdgeInsets.all(8),
+                                              child: selection.crop == null
+                                                  ? Image.file(
+                                                      File(selection.path),
+                                                      fit: BoxFit.contain,
+                                                      errorBuilder: (_, error, stack) => const Icon(Icons.broken_image),
+                                                    )
+                                                  : Image.memory(selection.crop!, fit: BoxFit.contain),
+                                            ),
+                                          ),
+                                        ),
+                                        Positioned(
+                                          top: 4,
+                                          right: 4,
+                                          child: IconButton.filledTonal(
+                                            tooltip: l10n.removeSelectedSticker(selection.name),
+                                            onPressed: busy
+                                                ? null
+                                                : () => setState(() => _selections.remove(selection)),
+                                            icon: const Icon(Icons.close),
+                                          ),
+                                        ),
+                                        if (selection.crop != null)
+                                          Positioned(
+                                            left: 4,
+                                            bottom: 4,
+                                            child: IconButton.filledTonal(
+                                              tooltip: l10n.resetCrop,
+                                              onPressed: busy ? null : () => setState(() => selection.crop = null),
+                                              icon: const Icon(Icons.undo),
+                                            ),
+                                          ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              Padding(
+                                padding: const EdgeInsets.only(top: 4),
+                                child: Text(selection.name, maxLines: 1, overflow: TextOverflow.ellipsis),
+                              ),
+                              if (selection.error != null)
+                                Tooltip(
+                                  message: selection.error!,
+                                  child: Text(
+                                    l10n.couldntLoadMedia,
+                                    style: TextStyle(color: Theme.of(context).colorScheme.error),
+                                  ),
+                                ),
+                            ],
+                          );
+                        },
+                      ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    if (hasErrors) ...[
+                      Text(l10n.batchImportErrors, style: TextStyle(color: Theme.of(context).colorScheme.error)),
+                      const SizedBox(height: 8),
+                    ],
+                    if (_saving) ...[
+                      LinearProgressIndicator(value: _prepared / _selections.length),
+                      const SizedBox(height: 8),
+                    ],
+                    FilledButton.icon(
+                      onPressed: busy || _selections.isEmpty ? null : _saveAll,
+                      icon: const Icon(Icons.check),
+                      label: Text(
+                        _saving
+                            ? l10n.savingStickers(_prepared, _selections.length)
+                            : l10n.saveAllStickers(_selections.length),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/pages/sticker_pack_page.dart
+++ b/lib/src/pages/sticker_pack_page.dart
@@ -13,6 +13,7 @@ import 'package:stickers/src/dialogs/error_dialog.dart';
 import 'package:stickers/src/globals.dart';
 import 'package:stickers/src/pages/crop_page.dart';
 import 'package:stickers/src/pages/default_page.dart';
+import 'package:stickers/src/pages/multi_crop_page.dart';
 import 'package:stickers/src/util.dart';
 
 class StickerPackPage extends StatefulWidget {
@@ -28,6 +29,8 @@ class StickerPackPage extends StatefulWidget {
 }
 
 class StickerPackPageState extends State<StickerPackPage> {
+  bool _importing = false;
+
   @override
   Widget build(BuildContext context) {
     return SafeArea(
@@ -78,7 +81,7 @@ class StickerPackPageState extends State<StickerPackPage> {
                     ),
                     itemBuilder: (context, index) {
                       if (index == widget.pack.stickers.length) {
-                        bool disabled = widget.pack.stickers.length >= 30;
+                        bool disabled = _importing || widget.pack.stickers.length >= 30;
                         return Container(
                           decoration: BoxDecoration(
                             borderRadius: BorderRadius.circular(24),
@@ -89,7 +92,7 @@ class StickerPackPageState extends State<StickerPackPage> {
                           ),
                           child: InkWell(
                             borderRadius: BorderRadius.circular(24),
-                            onTap: disabled ? null : () => _createSticker(index),
+                            onTap: disabled ? null : _createSticker,
                             child: Icon(
                               Icons.add,
                               size: 40,
@@ -190,35 +193,44 @@ class StickerPackPageState extends State<StickerPackPage> {
     );
   }
 
-  Future<void> _createSticker(int index) async {
+  Future<void> _createSticker() async {
+    if (_importing || widget.pack.stickers.length >= 30) return;
+    setState(() => _importing = true);
     try {
       final ImagePicker picker = ImagePicker();
       if (widget.pack.animated) {
         final XFile? video = await picker.pickVideo(source: ImageSource.gallery);
         if (video == null) return;
         if (!mounted) return;
-        Navigator.pushNamed(
+        await Navigator.pushNamed(
           context,
           "/crop_video",
           arguments: EditArguments(
             pack: widget.pack,
-            index: index,
+            index: widget.pack.stickers.length,
             mediaPath: video.path,
           ),
-        ).then((value) => setState(() {}));
+        );
       } else {
-        final XFile? image = await picker.pickImage(source: ImageSource.gallery);
-        if (image == null) return; //TODO add Snackbar warning
+        final remaining = 30 - widget.pack.stickers.length;
+        // The multi-image picker requires a limit of at least two.
+        final List<XFile> images;
+        if (remaining == 1) {
+          final image = await picker.pickImage(source: ImageSource.gallery);
+          images = image == null ? [] : [image];
+        } else {
+          images = await picker.pickMultiImage(limit: remaining);
+        }
         if (!mounted) return;
-        Navigator.pushNamed(
-          context,
-          "/crop",
-          arguments: EditArguments(
+        if (images.isEmpty) return;
+        await Navigator.of(context).push<void>(MaterialPageRoute(
+          builder: (_) => MultiCropPage(
             pack: widget.pack,
-            index: index,
-            mediaPath: image.path,
+            paths: images.take(remaining).map((image) => image.path).toList(),
+            // Some Android file providers do not enforce the picker limit.
+            selectionWasLimited: images.length > remaining,
           ),
-        ).then((value) => setState(() {}));
+        ));
       }
     } on Exception catch (e) {
       if (mounted) {
@@ -231,6 +243,8 @@ class StickerPackPageState extends State<StickerPackPage> {
               );
             });
       }
+    } finally {
+      if (mounted) setState(() => _importing = false);
     }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -395,7 +395,7 @@ packages:
     source: hosted
     version: "0.2.2+1"
   image_picker_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: image_picker_platform_interface
       sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,7 @@ dev_dependencies:
     sdk: flutter
 
   flutter_lints: ^6.0.0
+  image_picker_platform_interface: ^2.10.1
 
 flutter:
   generate: true

--- a/test/fake_picker.dart
+++ b/test/fake_picker.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
+
+class FakePicker extends ImagePickerPlatform {
+  List<XFile> images = [];
+  Completer<List<XFile>>? pending;
+  Exception? error;
+  int multiCalls = 0;
+  int singleCalls = 0;
+  int videoCalls = 0;
+  int? limit;
+
+  @override
+  Future<List<XFile>> getMultiImageWithOptions({
+    MultiImagePickerOptions options = const MultiImagePickerOptions(),
+  }) async {
+    multiCalls++;
+    limit = options.limit;
+    if (error != null) throw error!;
+    if (pending != null) return pending!.future;
+    return images;
+  }
+
+  @override
+  Future<XFile?> getImageFromSource({
+    required ImageSource source,
+    ImagePickerOptions options = const ImagePickerOptions(),
+  }) async {
+    singleCalls++;
+    return images.isEmpty ? null : images.first;
+  }
+
+  @override
+  Future<XFile?> getVideo({
+    required ImageSource source,
+    CameraDevice preferredCameraDevice = CameraDevice.rear,
+    Duration? maxDuration,
+  }) async {
+    videoCalls++;
+    return images.isEmpty ? null : images.first;
+  }
+}

--- a/test/multi_crop_test.dart
+++ b/test/multi_crop_test.dart
@@ -1,0 +1,355 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:ui' as ui;
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_editor/image_editor.dart';
+import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
+import 'package:stickers/generated/intl/app_localizations.dart';
+import 'package:stickers/src/globals.dart';
+import 'package:stickers/src/data/batch_import.dart';
+import 'package:stickers/src/data/sticker.dart';
+import 'package:stickers/src/data/sticker_pack.dart';
+import 'package:stickers/src/globals.dart' as globals;
+import 'package:stickers/src/pages/crop_page.dart';
+import 'package:stickers/src/pages/multi_crop_page.dart';
+import 'package:stickers/src/pages/sticker_pack_page.dart';
+import 'fake_picker.dart';
+
+class FakeImageEditor extends UnsupportedImageEditor {
+  FakeImageEditor(this.output);
+  final Uint8List output;
+  final edits = <ImageEditorOption>[];
+  int merges = 0;
+  Completer<void>? pending;
+  bool fail = false;
+  @override
+  Future<Uint8List?> editImage({required Uint8List image, required ImageEditorOption imageEditorOption}) async {
+    edits.add(imageEditorOption);
+    if (pending != null) await pending!.future;
+    if (fail) throw PlatformException(code: 'bad_image');
+    return output;
+  }
+
+  @override
+  Future<Uint8List?> mergeToMemory({required ImageMergeOption option}) async {
+    merges++;
+    return output;
+  }
+}
+
+Future<Uint8List> imageBytes(int width, int height) async {
+  final recorder = ui.PictureRecorder();
+  final canvas = Canvas(recorder);
+  canvas.drawColor(Colors.amber, BlendMode.src);
+  canvas.drawRect(Rect.fromLTWH(0, 0, width / 2, height.toDouble()), Paint()..color = Colors.teal);
+  final picture = recorder.endRecording();
+  final image = await picture.toImage(width, height);
+  final data = (await image.toByteData(format: ui.ImageByteFormat.png))!.buffer.asUint8List();
+  image.dispose();
+  picture.dispose();
+  return data;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late Directory directory;
+  late FakePicker picker;
+  late FakeImageEditor editor;
+  late ImagePickerPlatform oldPicker;
+  late ImageEditorPlatform oldEditor;
+  late StickerPack pack;
+  late Uint8List originalBytes, croppedBytes;
+  late String first, second;
+  setUpAll(() async {
+    final fonts = Platform.environment['STICKERS_TEST_FONTS'];
+    if (fonts != null) {
+      for (final font in {'Roboto': 'roboto-regular.ttf', 'MaterialIcons': 'materialicons-regular.otf'}.entries) {
+        final loader = FontLoader(font.key);
+        loader.addFont(File('$fonts/${font.value}').readAsBytes().then(ByteData.sublistView));
+        await loader.load();
+      }
+    }
+    originalBytes = await imageBytes(320, 160);
+    croppedBytes = await imageBytes(512, 512);
+  });
+  setUp(() {
+    Directory('build/test-work').createSync(recursive: true);
+    directory = Directory('build/test-work').createTempSync('batch_');
+    first = File('${directory.path}/first.png').absolute.path;
+    second = File('${directory.path}/second.png').absolute.path;
+    File(first).writeAsBytesSync(originalBytes);
+    File(second).writeAsBytesSync(originalBytes);
+    packsDir = '${directory.path}/packs';
+    Directory(packsDir).createSync();
+    pack = StickerPack('Test pack', 'Author', 'test', [], '1', false);
+    globals.packs = [pack];
+    File('$packsDir/packs.json').writeAsStringSync(jsonEncode([pack.toJson()]));
+    oldPicker = ImagePickerPlatform.instance;
+    oldEditor = ImageEditorPlatform.instance;
+    picker = FakePicker()..images = [XFile(first), XFile(second)];
+    editor = FakeImageEditor(croppedBytes);
+    ImagePickerPlatform.instance = picker;
+    ImageEditorPlatform.instance = editor;
+  });
+  tearDown(() {
+    ImagePickerPlatform.instance = oldPicker;
+    ImageEditorPlatform.instance = oldEditor;
+    try {
+      directory.deleteSync(recursive: true);
+    } on FileSystemException catch (error) {
+      // Windows image codecs may keep fixtures mapped until the test process
+      // exits. They live under build/ and can be cleaned with other build files.
+      if (error.osError?.errorCode != 32) rethrow;
+    }
+  });
+  Future<void> settle(WidgetTester tester) async {
+    await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 60)));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> until(WidgetTester tester, bool Function() ready) async {
+    for (var i = 0; i < 100 && !ready(); i++) {
+      await settle(tester);
+    }
+    expect(ready(), isTrue);
+  }
+
+  Future<void> showPack(WidgetTester tester, {int count = 0, Size size = const Size(390, 844)}) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(() async {
+      await tester.pumpWidget(const SizedBox());
+      PaintingBinding.instance.imageCache.clear();
+      PaintingBinding.instance.imageCache.clearLiveImages();
+      await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 100)));
+    });
+    pack.stickers.addAll(List.generate(count, (_) => Sticker(first, [], null)));
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: StickerPackPage(pack, () {})),
+        onGenerateRoute: (_) => MaterialPageRoute<void>(builder: (_) => const Scaffold(body: Text('Video crop'))),
+      ),
+    );
+    await settle(tester);
+    await tester.scrollUntilVisible(find.byIcon(Icons.add), 300, scrollable: find.byType(Scrollable).last);
+  }
+
+  Future<void> select(WidgetTester tester) async {
+    await tester.tap(find.byIcon(Icons.add));
+    await settle(tester);
+  }
+
+  Future<void> save(WidgetTester tester, int count) async {
+    await tester.tap(find.text('Save all ($count)'));
+    await until(tester, () => find.byType(MultiCropPage).evaluate().isEmpty);
+    await settle(tester);
+  }
+
+  testWidgets('gallery imports all images as-is without opening crop and preserves existing stickers', (tester) async {
+    await showPack(tester, count: 1);
+    final existing = pack.stickers.first;
+    await select(tester);
+    expect(find.byType(MultiCropPage), findsOneWidget);
+    expect(find.byType(CropPage), findsNothing);
+    expect(find.text('first.png'), findsOneWidget);
+    expect(find.text('second.png'), findsOneWidget);
+    expect(pack.stickers, [existing]);
+    await save(tester, 2);
+    expect(pack.stickers.length, 3);
+    expect(pack.stickers.first, same(existing));
+    expect(pack.imageDataVersion, '2');
+    for (final edit in editor.edits) {
+      final clip = edit.options.whereType<ClipOption>().single;
+      expect([clip.x, clip.y, clip.width, clip.height], [0, 0, 320, 160]);
+      final scale = edit.options.whereType<ScaleOption>().single;
+      expect([scale.width, scale.height], [512, 256]);
+    }
+    expect(editor.merges, 2);
+    expect(jsonDecode(File('$packsDir/packs.json').readAsStringSync()).single['stickers'].length, 3);
+  });
+  testWidgets('real crop screen returns a preview without saving; bulk save uses that crop', (tester) async {
+    await showPack(tester);
+    await select(tester);
+    await tester.tap(find.byWidgetPredicate((w) => w is Semantics && w.properties.label == 'Crop first.png'));
+    await until(tester, () {
+      final pages = find.byType(CropPage).evaluate();
+      return pages.isNotEmpty && (pages.single.widget as CropPage).editorKey.currentState?.getCropRect() != null;
+    });
+    await tester.tap(find.text('1:1'));
+    await settle(tester);
+    await tester.tap(find.text('Save crop'));
+    await until(tester, () => find.byType(CropPage).evaluate().isEmpty);
+    expect(find.byType(MultiCropPage), findsOneWidget);
+    expect(find.byTooltip('Reset crop'), findsOneWidget);
+    expect(pack.stickers, isEmpty);
+    final clip = editor.edits.single.options.whereType<ClipOption>().single;
+    expect(clip.width, clip.height);
+    await save(tester, 2);
+    expect(pack.stickers.length, 2);
+    expect(editor.merges, 2);
+    expect(File(pack.stickers.first.source).readAsBytesSync(), croppedBytes);
+  });
+  testWidgets('crop preview preserves the dev branch stretch option', (tester) async {
+    await showPack(tester);
+    await select(tester);
+    await tester.tap(find.byWidgetPredicate((w) => w is Semantics && w.properties.label == 'Crop first.png'));
+    await until(tester, () {
+      final pages = find.byType(CropPage).evaluate();
+      return pages.isNotEmpty && (pages.single.widget as CropPage).editorKey.currentState?.getCropRect() != null;
+    });
+    await tester.tap(find.text('Stretch'));
+    await settle(tester);
+    await tester.tap(find.text('Save crop'));
+    await until(tester, () => find.byType(CropPage).evaluate().isEmpty);
+    final edit = editor.edits.single;
+    final clip = edit.options.whereType<ClipOption>().single;
+    expect(clip.width, isNot(clip.height));
+    final scale = edit.options.whereType<ScaleOption>().single;
+    expect([scale.width, scale.height], [512, 512]);
+    expect(pack.stickers, isEmpty);
+    await save(tester, 2);
+    expect(pack.stickers.length, 2);
+    expect(pack.stickers.every((sticker) => sticker.editorData == null), isTrue);
+  });
+  testWidgets('back from crop keeps selection; back from gallery saves nothing', (tester) async {
+    await showPack(tester);
+    await select(tester);
+    await tester.tap(find.byWidgetPredicate((w) => w is Semantics && w.properties.label == 'Crop first.png'));
+    await settle(tester);
+    await tester.pageBack();
+    await settle(tester);
+    expect(find.text('Save all (2)'), findsOneWidget);
+    expect(pack.stickers, isEmpty);
+    await tester.pageBack();
+    await settle(tester);
+    expect(find.byType(MultiCropPage), findsNothing);
+    expect(pack.stickers, isEmpty);
+  });
+  testWidgets('saving blocks duplicate submissions and back navigation until the batch is committed', (tester) async {
+    editor.pending = Completer<void>();
+    await showPack(tester);
+    await select(tester);
+    final submit = tester.widget<FilledButton>(find.widgetWithText(FilledButton, 'Save all (2)')).onPressed!;
+    submit();
+    submit();
+    await until(tester, () => editor.edits.isNotEmpty);
+    await tester.binding.handlePopRoute();
+    await tester.pump();
+    expect(find.byType(MultiCropPage), findsOneWidget);
+    expect(pack.stickers, isEmpty);
+    editor.pending!.complete();
+    await until(tester, () => find.byType(MultiCropPage).evaluate().isEmpty);
+    expect(pack.stickers.length, 2);
+    expect(editor.merges, 2);
+  });
+
+  testWidgets('bad image is identified without a partial save; removing it allows retry', (tester) async {
+    File(second).writeAsStringSync('not an image');
+    await showPack(tester);
+    await select(tester);
+    await tester.tap(find.text('Save all (2)'));
+    await until(tester, () => find.textContaining('Nothing was saved.').evaluate().isNotEmpty);
+    expect(find.text('second.png'), findsOneWidget);
+    expect(pack.stickers, isEmpty);
+    expect(jsonDecode(File('$packsDir/packs.json').readAsStringSync()).single['stickers'], isEmpty);
+    await tester.tap(find.byTooltip('Remove second.png'));
+    await settle(tester);
+    await save(tester, 1);
+    expect(pack.stickers.length, 1);
+  });
+  testWidgets('removing all selections disables save', (tester) async {
+    await showPack(tester);
+    await select(tester);
+    await tester.tap(find.byTooltip('Remove first.png'));
+    await tester.pump();
+    await tester.tap(find.byTooltip('Remove second.png'));
+    await tester.pump();
+    expect(find.text('No images selected'), findsOneWidget);
+    expect(tester.widget<FilledButton>(find.widgetWithText(FilledButton, 'Save all (0)')).onPressed, isNull);
+  });
+  testWidgets('last slot uses single picker', (tester) async {
+    await showPack(tester, count: 29);
+    await select(tester);
+    expect(picker.singleCalls, 1);
+    await save(tester, 1);
+    expect(pack.stickers.length, 30);
+  });
+  testWidgets('provider ignoring limit cannot overfill pack', (tester) async {
+    picker.images.add(XFile(first));
+    await showPack(tester, count: 28);
+    await select(tester);
+    expect(picker.limit, 2);
+    expect(find.text('Save all (2)'), findsOneWidget);
+    await save(tester, 2);
+    expect(pack.stickers.length, 30);
+  });
+  testWidgets('full pack cannot open picker', (tester) async {
+    await showPack(tester, count: 30);
+    await select(tester);
+    expect(picker.multiCalls + picker.singleCalls, 0);
+  });
+  testWidgets('cancelled picker, repeated tap, and disposed page do not start an import', (tester) async {
+    picker.images = [];
+    await showPack(tester);
+    await select(tester);
+    expect(find.byType(MultiCropPage), findsNothing);
+    picker.pending = Completer<List<XFile>>();
+    await select(tester);
+    await tester.tap(find.byIcon(Icons.add));
+    expect(picker.multiCalls, 2);
+    await tester.pumpWidget(const SizedBox());
+    picker.pending!.complete([XFile(first)]);
+    await settle(tester);
+    expect(tester.takeException(), isNull);
+  });
+  testWidgets('animated packs retain video flow', (tester) async {
+    pack.animated = true;
+    await showPack(tester);
+    await select(tester);
+    expect(picker.videoCalls, 1);
+    expect(find.text('Video crop'), findsOneWidget);
+  });
+  test('failed manifest commit rolls back batch and permits retry', () async {
+    final manifest = File('$packsDir/packs.json');
+    manifest.deleteSync();
+    Directory(manifest.path).createSync();
+    await expectLater(saveStickerBatch(pack, [croppedBytes, croppedBytes]), throwsA(isA<FileSystemException>()));
+    expect(pack.stickers, isEmpty);
+    expect(pack.imageDataVersion, '1');
+    expect(Directory('$packsDir/${pack.id}').listSync(), isEmpty);
+    Directory(manifest.path).deleteSync();
+    await saveStickerBatch(pack, [croppedBytes, croppedBytes]);
+    expect(pack.stickers.length, 2);
+  });
+  test('bulk persistence enforces capacity', () async {
+    pack.stickers.addAll(List.generate(29, (_) => Sticker(first, [], null)));
+    await expectLater(saveStickerBatch(pack, [croppedBytes, croppedBytes]), throwsStateError);
+    expect(pack.stickers.length, 29);
+  });
+  testWidgets('gallery fits small phone and wide window', (tester) async {
+    await showPack(tester, size: const Size(360, 640));
+    await select(tester);
+    expect(tester.takeException(), isNull);
+    if (Platform.environment['STICKERS_TEST_FONTS'] != null) {
+      await until(tester, () => tester.widgetList<RawImage>(find.byType(RawImage)).every((w) => w.image != null));
+      await tester.runAsync(() async {
+        final boundary = tester.firstRenderObject<RenderRepaintBoundary>(find.byType(RepaintBoundary));
+        final image = await boundary.toImage();
+        final bytes = await image.toByteData(format: ui.ImageByteFormat.png);
+        image.dispose();
+        await File('../multi-crop-preview.png').writeAsBytes(bytes!.buffer.asUint8List());
+      });
+    }
+    tester.view.physicalSize = const Size(900, 600);
+    await settle(tester);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/multi_crop_test.dart
+++ b/test/multi_crop_test.dart
@@ -175,6 +175,34 @@ void main() {
     expect(editor.merges, 2);
     expect(jsonDecode(File('$packsDir/packs.json').readAsStringSync()).single['stickers'].length, 3);
   });
+  testWidgets('gallery decodes thumbnails to physical tile bounds without changing import resolution', (tester) async {
+    await tester.runAsync(() async {
+      File(first).writeAsBytesSync(await imageBytes(1600, 800));
+      File(second).writeAsBytesSync(await imageBytes(800, 1600));
+    });
+    await showPack(tester);
+    await select(tester);
+    for (final ratio in [1.0, 3.0]) {
+      tester.view.devicePixelRatio = ratio;
+      tester.view.physicalSize = Size(390 * ratio, 844 * ratio);
+      await settle(tester);
+      for (final entry in {'first.png': 2.0, 'second.png': .5}.entries) {
+        final tile = find.byWidgetPredicate((w) => w is Semantics && w.properties.label == 'Crop ${entry.key}');
+        final raw = find.descendant(of: tile, matching: find.byType(RawImage));
+        await until(tester, () => raw.evaluate().isNotEmpty && tester.widget<RawImage>(raw).image != null);
+        final decoded = tester.widget<RawImage>(raw).image!;
+        final bounds = tester.getSize(raw);
+        expect(decoded.width, lessThanOrEqualTo((bounds.width * ratio).ceil()));
+        expect(decoded.height, lessThanOrEqualTo((bounds.height * ratio).ceil()));
+        expect(decoded.width / decoded.height, closeTo(entry.value, .03));
+        expect(decoded.width, greaterThan(50 * ratio));
+      }
+    }
+    await save(tester, 2);
+    final clips = editor.edits.map((edit) => edit.options.whereType<ClipOption>().single).toList();
+    expect([clips[0].width, clips[0].height], [1600, 800]);
+    expect([clips[1].width, clips[1].height], [800, 1600]);
+  });
   testWidgets('real crop screen returns a preview without saving; bulk save uses that crop', (tester) async {
     await showPack(tester);
     await select(tester);


### PR DESCRIPTION
Added a selection gallery to review images, crop individual selections, and save the batch together. 

Included 15 regression tests, some localisation updates, and tried to keep it as minimal as reasonably possible.